### PR TITLE
Changed jogging record to reference API jogging data

### DIFF
--- a/Frontend/JoggingDiary/src/app/home/home.component.ts
+++ b/Frontend/JoggingDiary/src/app/home/home.component.ts
@@ -50,9 +50,7 @@ export class HomeComponent {
         joggingRecord =>  this.joggingData.splice(updateIndex, 1, jogging)
       );
     } else {
-      this.workoutService.add(jogging).subscribe(
-        joggingRecord => this.joggingData.push(jogging)
-      );
+      this.workoutService.add(jogging).subscribe((data: any) => this.joggingData.push(data));
     }
 
     this.currentJogging = this.setInitialValuesForJoggingData();


### PR DESCRIPTION
When a NEW jogging record was created, the previous implementation of this.joggingData.push(jogging) would use the jogging record from the angular form, instead of using the jogging record being returned from the backend API. This resulted in jogging records being pushed to the JoggingData array that did NOT contain a valid Id, "undefined".  This change allows a user to edit and delete newly created jogging records without having to refresh the window to update the record id using a get request.